### PR TITLE
Update packages

### DIFF
--- a/src/Edelstein.Core/Edelstein.Core.csproj
+++ b/src/Edelstein.Core/Edelstein.Core.csproj
@@ -16,16 +16,16 @@
         <PackageReference Include="Foundatio.Redis" Version="7.1.1608" />
         <PackageReference Include="IronPython" Version="2.7.9" />
         <PackageReference Include="LibLog" Version="5.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
         <PackageReference Include="MoonSharp" Version="2.0.0" />
-        <PackageReference Include="morelinq" Version="3.1.1" />
+        <PackageReference Include="morelinq" Version="3.2.0" />
         <PackageReference Include="Serilog" Version="2.8.0" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
+        <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     </ItemGroup>
 

--- a/src/Edelstein.Database/Edelstein.Database.csproj
+++ b/src/Edelstein.Database/Edelstein.Database.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="LiteDB" Version="4.1.4" />
-      <PackageReference Include="Marten" Version="3.5.0" />
+      <PackageReference Include="Marten" Version="3.9.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Edelstein.Provider/Edelstein.Provider.csproj
+++ b/src/Edelstein.Provider/Edelstein.Provider.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
       <PackageReference Include="LibLog" Version="5.0.6" />
       <PackageReference Include="MathParser.org-mXparser" Version="4.3.3" />
-      <PackageReference Include="morelinq" Version="3.1.1" />
+      <PackageReference Include="morelinq" Version="3.2.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Edelstein.Service.Game/Edelstein.Service.Game.csproj
+++ b/src/Edelstein.Service.Game/Edelstein.Service.Game.csproj
@@ -10,10 +10,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="CommandLineParser" Version="2.5.0" />
+        <PackageReference Include="CommandLineParser" Version="2.6.0" />
         <PackageReference Include="DotNet.Glob" Version="3.0.5" />
         <PackageReference Include="LibLog" Version="5.0.6" />
-        <PackageReference Include="morelinq" Version="3.1.1" />
+        <PackageReference Include="morelinq" Version="3.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Edelstein.Service.Login/Edelstein.Service.Login.csproj
+++ b/src/Edelstein.Service.Login/Edelstein.Service.Login.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="BCrypt.Net" Version="0.1.0" />
         <PackageReference Include="LibLog" Version="5.0.6" />
-        <PackageReference Include="morelinq" Version="3.1.1" />
+        <PackageReference Include="morelinq" Version="3.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Edelstein.Service.Login/Edelstein.Service.Login.csproj
+++ b/src/Edelstein.Service.Login/Edelstein.Service.Login.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="BCrypt.Net" Version="0.1.0" />
+        <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
         <PackageReference Include="LibLog" Version="5.0.6" />
         <PackageReference Include="morelinq" Version="3.2.0" />
     </ItemGroup>

--- a/src/Edelstein.Service.WebAPI/Edelstein.Service.WebAPI.csproj
+++ b/src/Edelstein.Service.WebAPI/Edelstein.Service.WebAPI.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BCrypt.Net" Version="0.1.0" />
+      <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
       <PackageReference Include="GraphQL" Version="2.4.0" />
       <PackageReference Include="GraphQL.Server.Authorization.AspNetCore" Version="3.4.0" />
       <PackageReference Include="GraphQL.Server.Core" Version="3.4.0" />

--- a/src/Edelstein.Service.WebAPI/Edelstein.Service.WebAPI.csproj
+++ b/src/Edelstein.Service.WebAPI/Edelstein.Service.WebAPI.csproj
@@ -18,9 +18,9 @@
       <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.4.0" />
       <PackageReference Include="GraphQL.Server.Ui.Voyager" Version="3.4.0" />
       <PackageReference Include="LibLog" Version="5.0.6" />
-      <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0-preview6.19307.2" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview5-19227-01" />
-      <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
+      <PackageReference Include="Serilog.AspNetCore" Version="3.0.0" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
     </ItemGroup>
 

--- a/test/Edelstein.Core.Tests/Edelstein.Core.Tests.csproj
+++ b/test/Edelstein.Core.Tests/Edelstein.Core.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20181205-02" />
-        <PackageReference Include="xunit" Version="2.4.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     </ItemGroup>
 
 </Project>

--- a/test/Edelstein.Network.Tests/Edelstein.Network.Tests.csproj
+++ b/test/Edelstein.Network.Tests/Edelstein.Network.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20181205-02" />
-        <PackageReference Include="xunit" Version="2.4.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Get rid of previews packages (with .NET 3 release)
Skip the `Foundatio` `8.x.x` release because of breaking changes with locks (https://github.com/FoundatioFx/Foundatio/releases/tag/v8.0.0)