### PR TITLE
fix wrong priority for plugin start boostrap

### DIFF
--- a/src/app/Edelstein.Application.Server/Bootstraps/StartPluginBootstrap.cs
+++ b/src/app/Edelstein.Application.Server/Bootstraps/StartPluginBootstrap.cs
@@ -24,7 +24,7 @@ public class StartPluginBootstrap<TContext> : IBootstrap
         _context = context;
         _manager = manager;
     }
-    public int Priority => BootstrapPriority.Init;
+    public int Priority => BootstrapPriority.Start;
 
     public async Task Start()
     {


### PR DESCRIPTION
would cause a parallel processing to look for hosted plugins before manager actually processed them from assembly